### PR TITLE
Fix CRGBA::Set(unsigned int) and CRGBA::ToInt + ARGB support

### DIFF
--- a/shared/game/shared.CRGBA.h
+++ b/shared/game/shared.CRGBA.h
@@ -31,9 +31,11 @@ public:
 
     CRGBA ToRGB() const;
     unsigned int ToInt() const;
+    unsigned int ToIntARGB() const;
     RwRGBA ToRwRGBA() const;
 
     void FromRwRGBA(RwRGBA const &rwcolor);
+    void FromARGB(unsigned int intValue);
 
     void Invert();
     CRGBA Inverted() const;

--- a/shared/game/shared.CRGBA.source.h
+++ b/shared/game/shared.CRGBA.source.h
@@ -40,10 +40,10 @@ void CRGBA::Set(unsigned char red, unsigned char green, unsigned char blue, unsi
 }
 
 void CRGBA::Set(unsigned int intValue) {
-    r = intValue & 0xFF;
-    g = (intValue >> 8) & 0xFF;
+    r = (intValue >> 24) & 0xFF;
     g = (intValue >> 16) & 0xFF;
-    g = (intValue >> 24) & 0xFF;
+    b = (intValue >> 8) & 0xFF;
+    a = intValue & 0xFF;
 }
 
 void CRGBA::Set(CRGBA const &rhs) {
@@ -59,7 +59,11 @@ void CRGBA::Set(RwRGBA const &rwcolor) {
 }
 
 unsigned int CRGBA::ToInt() const {
-    return r | (g << 8) | (b << 16) | (a << 24);
+    return a | (b << 8) | (g << 16) | (r << 24);
+}
+
+unsigned int CRGBA::ToIntARGB() const {
+    return b | (g << 8) | (r << 16) | (a << 24);
 }
 
 RwRGBA CRGBA::ToRwRGBA() const {
@@ -68,6 +72,13 @@ RwRGBA CRGBA::ToRwRGBA() const {
 
 void CRGBA::FromRwRGBA(RwRGBA const &rwcolor) {
     Set(rwcolor);
+}
+
+void CRGBA::FromARGB(unsigned int intValue) {
+    a = (intValue >> 24) & 0xFF;
+    r = (intValue >> 16) & 0xFF;
+    g = (intValue >> 8) & 0xFF;
+    b = intValue & 0xFF;
 }
 
 void CRGBA::Invert() {


### PR DESCRIPTION
Functions CRGBA::Set(unsigned int) and CRGBA::ToInt did not work correctly.

Current result:
```cpp
CRGBA color1(0x12345678);
color1.ToInt() = 0x12345678
color1.ToIntARGB() = 0x78123456
// r = 18, g = 52, b = 86, a = 120

CRGBA color2(0x12, 0x34, 0x56, 0x78);
color2.ToInt() = 0x12345678
color2.ToIntARGB() = 0x78123456
// r = 18, g = 52, b = 86, a = 120

CRGBA color3();
color3.FromARGB(0x12345678);
color2.ToInt() = 0x34567812
color2.ToIntARGB() = 0x12345678
// r = 52, g = 86, b = 120, a = 18
```