### PR TITLE
SA/Fix Burn Timer variables for CAutomobile and CBike

### DIFF
--- a/plugin_sa/game_sa/CAutomobile.h
+++ b/plugin_sa/game_sa/CAutomobile.h
@@ -86,7 +86,7 @@ public:
     float m_fMoveDirection;
     int field_8B4[6];
     int field_8C8[6];
-    int m_dwBurnTimer;
+    float m_fBurningTimer; // starts when vehicle health is lower than 250.0, car blows up when it hits 5000.0
     CEntity *m_pWheelCollisionEntity[4];
     CVector m_vWheelCollisionPos[4];
     char field_924;

--- a/plugin_sa/game_sa/CBike.h
+++ b/plugin_sa/game_sa/CBike.h
@@ -70,7 +70,7 @@ public:
     bool           m_bPedRightHandFixed;
     char field_7B6[2];
     int field_7B8;
-    int field_7BC;
+    float m_fBurningTimer; // starts when vehicle health is lower than 250.0, bike blows up when it hits 5000.0
     CEntity       *m_apWheelCollisionEntity[4];
     CVector        m_avTouchPointsLocalSpace[4];
     CEntity       *m_pDamager;


### PR DESCRIPTION
# Information
Up until now the burn timer for cars (or "automobiles" in general) and bikes was an integer.
This is incorrect.

As seen over here in [CBoat](https://github.com/DK22Pac/plugin-sdk/blob/master/plugin_sa/game_sa/CBoat.h#L50), it's supposed to be a `float` value ranging from `0.0f` to `5000.0f` - this means that the specific vehicle explodes roughly 5 seconds after it started burning.

This PR fixes the variable names and types for both CAutomobile and CBike.