### PR TITLE
Lowercase asm code

### DIFF
--- a/plugin_III/game_III/rw/rwplcore.h
+++ b/plugin_III/game_III/rw/rwplcore.h
@@ -519,8 +519,8 @@ RwFastRealToUInt32Inline(RwReal x)
 {
     RwUInt32 res;
 
-    __asm FLD DWord Ptr[x];
-    __asm FISTP DWord Ptr[res];
+    __asm fld dword ptr[x];
+    __asm fistp dword ptr[res];
     
     return(res);
 }

--- a/plugin_sa/game_sa/rw/rwplcore.h
+++ b/plugin_sa/game_sa/rw/rwplcore.h
@@ -220,8 +220,8 @@ RwFastRealToUInt32Inline(RwReal x)
 {
     RwUInt32 res;
 
-    __asm FLD DWord Ptr[x];
-    __asm FISTP DWord Ptr[res];
+    __asm fld dword ptr[x];
+    __asm fistp dword ptr[res];
     
     return(res);
 }

--- a/plugin_vc/game_vc/rw/rwplcore.h
+++ b/plugin_vc/game_vc/rw/rwplcore.h
@@ -519,8 +519,8 @@ RwFastRealToUInt32Inline(RwReal x)
 {
     RwUInt32 res;
 
-    __asm FLD DWord Ptr[x];
-    __asm FISTP DWord Ptr[res];
+    __asm fld dword ptr[x];
+    __asm fistp dword ptr[res];
     
     return(res);
 }


### PR DESCRIPTION
The clang compiler in VC++ mode doesn't seem to like upper cased asm code so I lower cased it to make it more portable, also it makes it more consistent with other bits of asm code