### PR TITLE
fix compilation plugin_sa in VS2019(16.8.2) with compiler v142

### DIFF
--- a/plugin_sa/game_sa/CRoadBlocks.h
+++ b/plugin_sa/game_sa/CRoadBlocks.h
@@ -31,12 +31,12 @@ public:
 	SUPPORTED_10US static unsigned int &roadbloxFlags;
 	SUPPORTED_10US static unsigned int &roadbloxDatSize;
 
-	SUPPORTED_10US_11US static void CRoadBlocks::RegisterScriptRoadBlock(CVector *cornerA, CVector *cornerB, byte type);
-	SUPPORTED_10US_11US static void CRoadBlocks::ClearScriptRoadBlocks();
-	SUPPORTED_10US static void CRoadBlocks::Init();
-	SUPPORTED_10US_11US static void CRoadBlocks::GenerateRoadBlockCopsForCar(CVehicle *car, int pedsPositionsType, byte type);
-	SUPPORTED_10US_11US static void CRoadBlocks::CreateRoadBlockBetween2Points(CVector *a, CVector *b, byte type);
-	SUPPORTED_10US_11US static void CRoadBlocks::GenerateRoadBlocks();
+	SUPPORTED_10US_11US static void RegisterScriptRoadBlock(CVector *cornerA, CVector *cornerB, byte type);
+	SUPPORTED_10US_11US static void ClearScriptRoadBlocks();
+	SUPPORTED_10US static void Init();
+	SUPPORTED_10US_11US static void GenerateRoadBlockCopsForCar(CVehicle *car, int pedsPositionsType, byte type);
+	SUPPORTED_10US_11US static void CreateRoadBlockBetween2Points(CVector *a, CVector *b, byte type);
+	SUPPORTED_10US_11US static void GenerateRoadBlocks();
 };
 
 #include "meta/meta.CRoadBlocks.h"

--- a/shared/StringUtils.h
+++ b/shared/StringUtils.h
@@ -5,6 +5,7 @@
     Do not delete this comment block. Respect others' work!
 */
 #pragma once
+#include <cstring>
 
 namespace StringUtils {
 


### PR DESCRIPTION
After upgrading VS2019 from 16.8.1 to 16.8.2 it also break compilation with compiler v142. This PR fix compilation for v142 and do not break another compilers