### PR TITLE
Fix CPed m_nCreatedBy

### DIFF
--- a/plugin_sa/game_sa/CPed.h
+++ b/plugin_sa/game_sa/CPed.h
@@ -201,7 +201,8 @@ public:
     } m_nPedFlags;
     CPedIntelligence   *m_pIntelligence;
     CPlayerData        *m_pPlayerData;
-    unsigned int        m_nCreatedBy;
+    unsigned char       m_nCreatedBy;
+    char                field_485[3];
     AnimBlendFrameData *m_apBones[19];
     unsigned int        m_nAnimGroup;
     CVector2D           m_vecAnimMovingShiftLocal;


### PR DESCRIPTION
If Open Limit Adjuster is installed, some weird value is returned due to the next 3 bytes. Works fine now, for both — installed or not.
https://forum.mixmods.com.br/f285-help-with-the-game/t5351-sa-help-open-limit-adjuster-bug-and-glowing-pickup