### PR TITLE
Linux crosscompilation: Fix include casing

### DIFF
--- a/hooking/README.md
+++ b/hooking/README.md
@@ -4,7 +4,7 @@ Sample:
 
 ```cpp
 #include "stdafx.h"
-#include <Windows.h>
+#include <windows.h>
 #include "Hooking.Patterns.h"
 
 int main()

--- a/plugin_III/game_III/rw/skeleton.h
+++ b/plugin_III/game_III/rw/skeleton.h
@@ -24,7 +24,7 @@
  *
  */
 #include "rwcore.h"
-#include <Windows.h>
+#include <windows.h>
 
 /* Default arena size depending on platform. */
 

--- a/plugin_sa/game_sa/CClothesBuilder.h
+++ b/plugin_sa/game_sa/CClothesBuilder.h
@@ -7,7 +7,7 @@
 */
 #pragma once
 #include "PluginBase.h"
-#include "renderware.h"  // important
+#include "RenderWare.h"  // important
 #include "CPedClothesDesc.h"
 
 

--- a/plugin_sa/game_sa/rw/skeleton.h
+++ b/plugin_sa/game_sa/rw/skeleton.h
@@ -24,7 +24,7 @@
  *
  */
 #include "rwcore.h"
-#include <Windows.h>
+#include <windows.h>
 
 /* Default arena size depending on platform. */
 

--- a/plugin_vc/game_vc/rw/skeleton.h
+++ b/plugin_vc/game_vc/rw/skeleton.h
@@ -24,7 +24,7 @@
  *
  */
 #include "rwcore.h"
-#include <Windows.h>
+#include <windows.h>
 
 /* Default arena size depending on platform. */
 

--- a/shared/DynAddress.cpp
+++ b/shared/DynAddress.cpp
@@ -6,7 +6,7 @@
 */
 
 #include "DynAddress.h"
-#include <Windows.h>
+#include <windows.h>
 #include "Base.h"
 #include "../hooking/Hooking.Patterns.h"
 #include "../injector/hooking.hpp"

--- a/shared/Error.h
+++ b/shared/Error.h
@@ -5,7 +5,7 @@
     Do not delete this comment block. Respect others' work!
 */
 #pragma once
-#include <Windows.h>
+#include <windows.h>
 #include <cstdio>
 #include <string>
 #include "extensions\Paths.h"

--- a/shared/Other.cpp
+++ b/shared/Other.cpp
@@ -5,7 +5,7 @@
     Do not delete this comment block. Respect others' work!
 */
 #include "Other.h"
-#include <Windows.h>
+#include <windows.h>
 #include <fstream>
 #include <ctime>
 

--- a/shared/Other.h
+++ b/shared/Other.h
@@ -9,7 +9,7 @@
 #include <locale>
 #include <codecvt>
 
-#include <Windows.h>
+#include <windows.h>
 
 #if defined(GTA3) || defined(GTAVC) || defined(GTASA) || defined(GTAIV)
 #include "CTimer.h"

--- a/shared/extensions/Paths.cpp
+++ b/shared/extensions/Paths.cpp
@@ -5,7 +5,7 @@
     Do not delete this comment block. Respect others' work!
 */
 #include "Paths.h"
-#include <Windows.h>
+#include <windows.h>
 #include "Error.h"
 
 #define MAX_VALUE(a,b) (((a) > (b)) ? (a) : (b))

--- a/shared/extensions/Shader.h
+++ b/shared/extensions/Shader.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #ifdef GTASA
-#include <Windows.h>
+#include <windows.h>
 #include "dxsdk/d3dx9.h"
 #include <stdio.h>
 #include <vector>


### PR DESCRIPTION
Because Linux is case sensitive, the casing on the include files must match the included file.
This change does not affect native windows compilation in any negative way.

This fixes #170 