### PR TITLE
Linux crosscompilation: make CTaskSimpleJetpack include match the original casing

### DIFF
--- a/plugin_sa/game_sa/CTaskSimpleJetPack.cpp
+++ b/plugin_sa/game_sa/CTaskSimpleJetPack.cpp
@@ -4,7 +4,7 @@
     https://github.com/DK22Pac/plugin-sdk
     Do not delete this comment block. Respect others' work!
 */
-#include "CTaskSimpleJetPack.h"
+#include "CTaskSimpleJetpack.h"
 
 float &CTaskSimpleJetPack::THRUST_NOMINAL         = *(float *)0x8D2F38; // 0.8
 float &CTaskSimpleJetPack::THRUST_FULL            = *(float *)0x8D2F3C; // 0.6


### PR DESCRIPTION
related to #171
I missed this file, but this is for real the last gta sa related casing change (as I'm focusing only on gta sa).