### PR TITLE
Fix: compile errors in hooking.patterns.h with mingw

### DIFF
--- a/hooking/Hooking.Patterns.h
+++ b/hooking/Hooking.Patterns.h
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <vector>
 #include <string_view>
+#include <string>
 
 #if defined(_CPPUNWIND) && !defined(PATTERNS_SUPPRESS_EXCEPTIONS)
 #define PATTERNS_ENABLE_EXCEPTIONS
@@ -196,7 +197,7 @@ namespace hook
 		template<typename T = void>
 		inline auto get_first(ptrdiff_t offset = 0)
 		{
-			return get_one().get<T>(offset);
+			return get_one().template get<T>(offset);
 		}
 
 		template <typename Pred>


### PR DESCRIPTION
included the string header for mingw and fixed the "expected primary-expression before '>' token" in line 200