### PR TITLE
Fix: missing header in other.h while compiling with mingw

### DIFF
--- a/shared/Other.h
+++ b/shared/Other.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <locale>
 #include <codecvt>
+#include <sys/stat.h>
 
 #include <windows.h>
 


### PR DESCRIPTION
While compiling with mingw an error will be thrown at line 128 in other.h "return (stat(name, &buffer) == 0);" unless the sys/stat.h header is included. Doing a quick test in godbolt's compilerexplorer msvc has this header as well and likely it's just implicitly included in msvc https://gcc.godbolt.org/z/vb549MxrG