### PR TITLE
mingw: fix include error in recent versions of mingw

### DIFF
--- a/hooking/Hooking.Patterns.h
+++ b/hooking/Hooking.Patterns.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <string_view>
 #include <string>
+#include <cstdint>
 
 #if defined(_CPPUNWIND) && !defined(PATTERNS_SUPPRESS_EXCEPTIONS)
 #define PATTERNS_ENABLE_EXCEPTIONS


### PR DESCRIPTION
As of mingw 13.2.0 cstdint needs to be included explicitly. I said the last commit was the last patch needed to compile plugin-sdk with mingw, but then I updated mingw and it needed this last change as well.