### PR TITLE
fix: correct types so it compiles on later C++ versions

### DIFF
--- a/shared/Pattern.h
+++ b/shared/Pattern.h
@@ -30,7 +30,7 @@ namespace plugin {
                 goto return_addr;
             }
             {
-                auto& p = hook::pattern(bytes);
+                auto p = hook::pattern(bytes);
                 a = p.empty() ? 0x0 : (uint32_t)p.get_first(0);
             }
             patternMap->emplace(bytes, a);
@@ -51,7 +51,7 @@ namespace plugin {
                 goto return_addr;
             }
             {
-                auto& p = hook::module_pattern(module, bytes);
+                auto p = hook::module_pattern(module, bytes);
                 a = p.empty() ? 0x0 : (uint32_t)p.get_first(0);
             }
             modulePatternMap->emplace(bytes, a);

--- a/shared/SpriteLoader.cpp
+++ b/shared/SpriteLoader.cpp
@@ -171,7 +171,7 @@ make_slot:
 #endif
 
     CSprite2d* SpriteLoader::GetSprite(std::string const& name) {
-        auto& s = spritesMap.find(name);
+        const auto& s = spritesMap.find(name);
         if (s != spritesMap.end()) {
             if (buf > spriteBuf.size() - 1)
                 buf = 0;


### PR DESCRIPTION
plugin_vc (and other plugins, probably) failed to compile on /std:c++latest on my system because of these errors:
```
 1>C:\Users\overanalytcl\plugin-sdk\shared\Pattern.h(33,1): error C2440: 'initializing': cannot convert from 'hook::pattern' to 'hook::pattern &'
1>C:\Users\overanalytcl\plugin-sdk\shared\Pattern.h(33,25): message : A non-const reference may only be bound to an lvalue
1>C:\Users\overanalytcl\plugin-sdk\shared\Pattern.h(54,1): error C2440: 'initializing': cannot convert from 'hook::pattern' to 'hook::pattern &'
1>C:\Users\overanalytcl\plugin-sdk\shared\Pattern.h(54,25): message : A non-const reference may only be bound to an lvalue

1>C:\Users\overanalytcl\plugin-sdk\shared\SpriteLoader.cpp(174,40): error C2440: 'initializing': cannot convert from 'std::_List_iterator<std::_List_val<std::_List_simple_types<_Ty>>>' to 'std::_List_iterator<std::_List_val<std::_List_simple_types<_Ty>>> &'
1>        with
1>        [
1>            _Ty=std::pair<const std::string,plugin::texClass *>
1>        ]
1>C:\Users\overanalytcl\plugin-sdk\shared\SpriteLoader.cpp(174,17): message : A non-const reference may only be bound to an lvalue
```

This PR attempts to solve that. In `Pattern.h`'s case, `..\hooking\Hooking.Patterns.h` has:
```cpp
        inline auto module_pattern(void* module, std::string_view bytes)
        {
                return make_module_pattern(module, std::move(bytes));
        } 
```
which calls:
```cpp
        inline auto make_module_pattern(void* module, std::string_view bytes)
        {
                return pattern(module, std::move(bytes));
        }
```
and auto is deduced as `basic_pattern<assert_err_policy>` which is not a reference.

In SpriteLoader's case, in https://en.cppreference.com/w/cpp/language/auto it says that the type deduction for auto is ruled by the same rules as template argument deduction: https://en.cppreference.com/w/cpp/language/template_argument_deduction. C++ has a feature to extend the lifetime of an object if it's bound to a `const auto&`, thus it works for both lvalues and rvalues (temporary variables). Even if you could do something like `auto&&`, we're not changing `s`, thus it's a perfectly sensible choice.

Edit: seems like Github is confused about the commit author, ignore that aspect.