### PR TITLE
plugin_iv fix

### DIFF
--- a/plugin_IV/game_IV/CWeaponData.h
+++ b/plugin_IV/game_IV/CWeaponData.h
@@ -47,7 +47,7 @@ public:
 
 public:
     CAmmoData* GetAmmoData();
-    CAmmoData* CWeaponData::GetAmmoDataExtraCheck();
+    CAmmoData* GetAmmoDataExtraCheck();
     void SetCurrentWeapon(int32_t arg1, int32_t slot, bool arg3, CPed* ped);
     int32_t GetAmountOfAmmunition(int32_t weaponSlot);
     void GiveWeapon(eWeaponType weaponType, int32_t ammo, int8_t setAsCurrent, int8_t arg4, int8_t arg5);

--- a/plugin_IV/game_IV/rage/fiAssetManager.h
+++ b/plugin_IV/game_IV/rage/fiAssetManager.h
@@ -16,7 +16,7 @@ namespace rage {
     class fiAssetManager {
     public:
         char m_Paths[4][512];
-        rage::fiAssetManager::Entry m_Entries[8];
+        rage::Entry m_Entries[8];
         int32_t m_SP;
         uint32_t m_PathCount;
         int32_t m_WritePath;

--- a/plugin_IV/game_IV/rage/grcImage.h
+++ b/plugin_IV/game_IV/rage/grcImage.h
@@ -29,7 +29,7 @@ namespace rage {
             FORMAT_MASK = 0x1FFFFFFF,
         };
 
-        typedef CTextureDecodeRequestDesc::Type rage::grcImage::Format;
+        typedef CTextureDecodeRequestDesc::Type Format;
 
     private:
         uint16_t m_Width;


### PR DESCRIPTION
`1>C:\Users\*****\plugin-sdk\plugin_iv\game_IV\rage\grcImage.h(32,71): error C4596: 'Format': illegal qualified name in member declaration`
`1>C:\Users\*****\plugin-sdk\plugin_iv\game_IV\CWeaponData.h(50,50): error C4596: 'GetAmmoDataExtraCheck': illegal qualified name in member declaration`
`1>C:\Users\*****\plugin-sdk\plugin_iv\game_IV\rage\fiAssetManager.h(19,37): error C4596: 'Entry': illegal qualified name in member declaration
`

1. Inside the `fiAssetManager` it does not exist `Entry` and it belongs to the `rage` namespace only
2. `CWeaponData::GetAmmoDataExtraCheck()` it's pointless and doesn't work and it's already calling it's internal functions within that class. The same thing applies to `rage::grcImage::Format;`