### PR TITLE
Fix missing m_nSelectedSaveGame in CMenuManager

### DIFF
--- a/plugin_sa/game_sa/CMenuManager.h
+++ b/plugin_sa/game_sa/CMenuManager.h
@@ -193,6 +193,7 @@ struct PLUGIN_API CMenuScreen {
     } m_aEntries[NUM_ENTRIES];
 };
 
+#pragma pack(push,1)
 class PLUGIN_API CMenuManager {
 public:
     char m_nStatsScrollDir;
@@ -298,13 +299,15 @@ public:
     bool m_bTexturesLoaded;
     char m_nCurrentMenuPage;
     char m_nPreviousMenuPage;
-    char m_nCurrentSelectedMissionPack;
+    char m_nSelectedSaveGame;
+
+    char m_nSelectedMissionPack;
     struct MissionPackStruct {
         uint8_t id;
         char name[260];
     };
+    MissionPackStruct m_MissionPacks[25];
 
-    MissionPackStruct m_nSelectedMissionPack[25];
     bool m_bChangeVideoMode;
     char field_1ADF;
     int field_1AE0;
@@ -444,7 +447,7 @@ public:
     void RequestFrontEndShutDown();
     void RequestFrontEndStartUp();
 };
-
+#pragma pack(pop)
 VALIDATE_SIZE(CMenuManager, 0x1B78);
 
 extern CMenuManager &FrontEndMenuManager;


### PR DESCRIPTION
Fixed missing **m_nSelectedSaveGame** field.
Renamed mpack info array to **m_MissionPacks**.

Enabled struct packing for **CMenuManager** to ensure **VALIDATE_SIZE** tests actual struct contents.
Pragma pack 1 should probably be set in **PLUGIN_API** to avoid mistakes like that.

Tested value of **m_nMouseOldPosX** to make sure memory layout is now correct.

@gennariarmando seems your fault