### PR TITLE
Fix need for _CRT_SECURE_NO_WARNINGS in Other.h and gvm.hpp headers

### DIFF
--- a/injector/gvm/gvm.hpp
+++ b/injector/gvm/gvm.hpp
@@ -101,16 +101,18 @@ class game_version_manager
         // Gets the game version as text, the buffer must contain at least 32 bytes of space.
         char* GetVersionText(char* buffer)
         {
+            static constexpr size_t BUFFER_SIZE = 32;
+
             if(this->IsUnknown())
             {
-                strcpy(buffer, "UNKNOWN GAME");
+                strcpy_s(buffer, BUFFER_SIZE, "UNKNOWN GAME");
                 return buffer;
             }
 
             const char* g = this->IsIII() ? "III" : this->IsVC() ? "VC" : this->IsSA() ? "SA" : this->IsIV() ? "IV" : this->IsEFLC() ? "EFLC" : "UNK";
             const char* r = this->IsUS()? "US" : this->IsEU()? "EURO" : "UNK_REGION";
             const char* s = this->IsSteam()? "Steam" : "";
-            sprintf(buffer, "GTA %s %d.%d.%d.%d %s%s", g, major, minor, majorRevision, minorRevision, r, s);
+            sprintf_s(buffer, BUFFER_SIZE, "GTA %s %d.%d.%d.%d %s%s", g, major, minor, majorRevision, minorRevision, r, s);
             return buffer;
         }
 
@@ -129,7 +131,7 @@ class game_version_manager
         void RaiseIncompatibleVersion()
         {
             char buf[128], v[32];
-            sprintf(buf,
+            sprintf_s(buf,
                 "An incompatible exe version has been detected! (%s)\nContact the mod creator!",
                 GetVersionText(v)
                 );

--- a/shared/Other.h
+++ b/shared/Other.h
@@ -98,13 +98,13 @@ namespace plugin {
 
     static std::wstring ToWString(const std::string& str) {
         std::wstring wstr(str.size(), L'\0');
-        std::mbstowcs(&wstr[0], str.c_str(), str.size());
+        mbstowcs_s(nullptr, wstr.data(), wstr.size() + 1, str.c_str(), str.size());
         return wstr;
     }
 
     static std::string ToString(const std::wstring& wstr) {
         std::string str(wstr.size() * MB_CUR_MAX, '\0');
-        std::wcstombs(&str[0], wstr.c_str(), str.size());
+        wcstombs_s(nullptr, str.data(), str.size() + 1, wstr.c_str(), wstr.size());
         return str;
     }
 


### PR DESCRIPTION
Do not force projects using **Other.h** or **gvm.hpp** headers to use global preprocessor directive **_CRT_SECURE_NO_WARNINGS**.