### PR TITLE
Fix swapped top and bottom fields in CRect

### DIFF
--- a/plugin_III/game_III/CRect.h
+++ b/plugin_III/game_III/CRect.h
@@ -12,9 +12,9 @@
 class CRect {
 public:
     float left;
-    float bottom;
-    float right;
     float top;
+    float right;
+    float bottom;
 
     CRect(plugin::dummy_func_t) {}
 

--- a/plugin_iii_unreal/game_iii_unreal/CRect.h
+++ b/plugin_iii_unreal/game_iii_unreal/CRect.h
@@ -10,9 +10,9 @@
 class CRect {
 public:
     float left;
-    float bottom;
-    float right;
     float top;
+    float right;
+    float bottom;
 
 public:
     CRect(plugin::dummy_func_t) {

--- a/plugin_sa_unreal/game_sa_unreal/CRect.h
+++ b/plugin_sa_unreal/game_sa_unreal/CRect.h
@@ -10,9 +10,9 @@
 class CRect {
 public:
     float left;
-    float bottom;
-    float right;
     float top;
+    float right;
+    float bottom;
 
 public:
     CRect(plugin::dummy_func_t) {

--- a/plugin_vc/game_vc/CRect.h
+++ b/plugin_vc/game_vc/CRect.h
@@ -12,9 +12,9 @@
 class CRect {
 public:
     float left;
-    float bottom;
-    float right;
     float top;
+    float right;
+    float bottom;
 
     CRect(plugin::dummy_func_t) {}
 

--- a/plugin_vc_unreal/game_vc_unreal/CRect.h
+++ b/plugin_vc_unreal/game_vc_unreal/CRect.h
@@ -10,9 +10,9 @@
 class CRect {
 public:
     float left;
-    float bottom;
-    float right;
     float top;
+    float right;
+    float bottom;
 
 public:
     CRect(plugin::dummy_func_t) {


### PR DESCRIPTION
Entering proper coordinates for sprite causes drawing it upside-down.
Top is also first in modern reversed: https://github.com/gta-reversed/gta-reversed/blob/master/source/game_sa/Core/Rect.h#L47
No idea about GTA2