### PR TITLE
SA: add CObject ctor's & fix CExplosion::AddExplosion

### DIFF
--- a/plugin_sa/game_sa/CExplosion.cpp
+++ b/plugin_sa/game_sa/CExplosion.cpp
@@ -61,7 +61,7 @@ void CExplosion::Initialise() {
 }
 
 // Converted from cdecl bool CExplosion::AddExplosion(CEntity *victim,CEntity *creator,eExplosionType explosionType,CVector const&posn,uint time,uchar makeSound,float camShake,uchar visibility) 0x736A50
-bool CExplosion::AddExplosion(CEntity* victim, CEntity* creator, eExplosionType explosionType, CVector const& posn, unsigned int time, unsigned char makeSound, float camShake, unsigned char visibility) {
+bool CExplosion::AddExplosion(CEntity* victim, CEntity* creator, eExplosionType explosionType, CVector posn, unsigned int time, unsigned char makeSound, float camShake, unsigned char visibility) {
     return plugin::CallAndReturn<bool, 0x736A50, CEntity*, CEntity*, eExplosionType, CVector, unsigned int, unsigned char, float, unsigned char>(victim, creator, explosionType, posn, time, makeSound, camShake, visibility);
 }
 

--- a/plugin_sa/game_sa/CExplosion.h
+++ b/plugin_sa/game_sa/CExplosion.h
@@ -63,7 +63,7 @@ public:
     static bool TestForExplosionInArea(eExplosionType explosionType, float x1, float y1, float z1, float x2, float y2, float z2);
     static void RemoveAllExplosionsInArea(CVector posn, float radius);
     static void Initialise();
-    static bool AddExplosion(CEntity* victim, CEntity* creator, eExplosionType explosionType, CVector const& posn, unsigned int time, unsigned char makeSound, float camShake, unsigned char visibility);
+    static bool AddExplosion(CEntity* victim, CEntity* creator, eExplosionType explosionType, CVector posn, unsigned int time, unsigned char makeSound, float camShake, unsigned char visibility);
     static void Update();
 };
 

--- a/plugin_sa/game_sa/CObject.cpp
+++ b/plugin_sa/game_sa/CObject.cpp
@@ -22,6 +22,14 @@ CObject::CObject() : CPhysical(plugin::dummy) {
     plugin::CallMethod<0x5A1D10, CObject*>(this);
 }
 
+CObject::CObject(int32_t model, bool create) : CPhysical(plugin::dummy) {
+    plugin::CallMethod<0x5A1D70, CObject*, int32_t, bool>(this, model, create);
+}
+
+CObject::CObject(CDummyObject* dummy) : CPhysical(plugin::dummy) {
+    plugin::CallMethod<0x5A1DF0, CObject*, CDummyObject*>(this, dummy);
+}
+
 CObject::~CObject() {
     plugin::CallMethod<0x59F660, CObject*>(this);
 }

--- a/plugin_sa/game_sa/CObject.h
+++ b/plugin_sa/game_sa/CObject.h
@@ -90,6 +90,8 @@ public:
     static void* operator new(unsigned int size, int poolRef);
     static void operator delete(void* data);
     CObject();
+    CObject(int32_t modelId, bool bCreate);
+    CObject(CDummyObject* dummyObj);
     ~CObject();
     void SetIsStatic(bool isStatic);
     void ProcessGarageDoorBehaviour();


### PR DESCRIPTION
fixed a crash/UB with the CExplosion::AddExplosion func because of CVector being a const reference + CObject ctors