### PR TITLE
Fix menuDrawingEvent for classic VC.

### DIFF
--- a/shared/Events.h
+++ b/shared/Events.h
@@ -22,7 +22,7 @@ namespace plugin {
     class Events {
     public:
 #ifdef GTASA
-        static inline CdeclEvent <AddressList<0x53C6DB, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> restartGameEvent;
+        static inline CdeclEvent    <AddressList<0x53C6DB, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> restartGameEvent;
 
         static inline CdeclEvent    <AddressList<0x53E293, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> drawingEvent;
         static inline CdeclEvent    <AddressList<0x53E4FF, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()> drawHudEvent;
@@ -83,6 +83,12 @@ namespace plugin {
             0x5BA340, H_CALL,
             0x5D4FD7, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()>          initScriptsEvent;
         static inline CdeclEvent    <AddressList<0x53C077, H_CALL>, PRIORITY_AFTER, ArgPickNone, void()>          processScriptsEvent;
+
+        static inline ThiscallEvent <AddressList<
+            0x53E82D, H_CALL, // before game session
+            0x53EB8C, H_CALL>, // during game session
+            PRIORITY_AFTER, ArgPickNone, void(CMenuManager*)> menuDrawingEvent;
+
         static inline CdeclEvent    <AddressList<0x53ECA1, H_CALL>, PRIORITY_AFTER, ArgPickNone, bool()>          attachRwPluginsEvent;
 #endif
 #ifdef GTAVC


### PR DESCRIPTION
Previously hook was set on some random text print inside menu drawing. Hooked call's arguments were ignored causing crash.