### PR TITLE
add ported SetHealth & AddHealth methods for CPed

### DIFF
--- a/plugin_IV/game_IV/CPed.cpp
+++ b/plugin_IV/game_IV/CPed.cpp
@@ -53,3 +53,11 @@ CVehicle* CPed::GetVehiclePedWouldEnter(CPed* ped, rage::Vector3 const& pos, boo
 bool CPed::IsPedDead(CPed* ped) {
     return plugin::CallAndReturnDyn<bool>(gpattern("8B 44 24 04 80 B8 ? ? ? ? ? 74 10 8B 88 ? ? ? ? 83 F9 01 74 0E 83 F9 02 74 09 83 B8 ? ? ? ? ? 75 03"), ped);
 }
+
+void CPed::SetHealth(float health, int unknown) {
+    plugin::CallVirtualMethod<61>(this, health, unknown);
+}
+
+void CPed::AddHealth(float health) {
+    plugin::CallVirtualMethod<62>(this, health);
+}

--- a/plugin_IV/game_IV/CPed.h
+++ b/plugin_IV/game_IV/CPed.h
@@ -504,6 +504,8 @@ public:
     bool CanStartMission();
     void SetRelationship(int32_t level, int32_t group);
     CControl* GetControlFromPlayer();
+    void SetHealth(float health, int unknown = 0);
+    void AddHealth(float health);
 
 public:
     static CVehicle* GetVehiclePedWouldEnter(CPed* ped, rage::Vector3 const& pos, bool arg2);


### PR DESCRIPTION
I wanted to port my old script from IV-SDK and realised these methods were missing so I thought I'd add them.

Original sources:
[1]: https://github.com/Zolika1351/iv-sdk/blob/dddbd3f54b146bdb3a9852809e48e5cb169af3cd/include/CPed.h#L174
[2]: https://github.com/Zolika1351/iv-sdk/blob/dddbd3f54b146bdb3a9852809e48e5cb169af3cd/include/CPed.h#L178