### PR TITLE
Update return type of ConstructStatLines from void to int

### DIFF
--- a/plugin_vc/game_vc/CStats.cpp
+++ b/plugin_vc/game_vc/CStats.cpp
@@ -390,7 +390,9 @@ void CStats::LoadStats(unsigned char* bufferPointer, unsigned int structSize)
 }
 
 // Converted from static void __cdecl CStats::ConstructStatLine(int a1) 0x4CB085
-void CStats::ConstructStatLine(int a1)
+// Updated to int - as there is a specific line in PrintStatBox function which 
+// expects a return value of row number by passing 99999
+int CStats::ConstructStatLine(int a1)
 {
-	((void (__cdecl *)(int))0x4CB085)(a1);
+	return ((int (__cdecl *)(int))0x4CB085)(a1);
 }

--- a/plugin_vc/game_vc/CStats.h
+++ b/plugin_vc/game_vc/CStats.h
@@ -138,5 +138,5 @@ public:
 	static void BuildStatLine(char* a1, void* a2, int a3, void* a4, int a5);
 	static void SaveStats(unsigned char* bufferPointer, unsigned int* structSize);
 	static void LoadStats(unsigned char* bufferPointer, unsigned int structSize);
-	static void ConstructStatLine(int a1);
+	static int ConstructStatLine(int a1);
 };


### PR DESCRIPTION
Update return type of ConstructStatLines from void to int. There is specific case in stat box printing which requires a return value from this function to get number of rows. This is done by passing an out of bounds index as input.

`push    1869Fh
call    _ZN6CStats17ConstructStatLineEi ; CStats::ConstructStatLine(int)
mov     ebp, eax`