### PR TITLE
Base CVector on RwV3d

### DIFF
--- a/examples/UnitTests/source/Test_CVector.h
+++ b/examples/UnitTests/source/Test_CVector.h
@@ -48,7 +48,6 @@ UTEST(CVector, ctor_CVector)
     EXPECT_EQ(v.z, 3.0f);
 }
 
-#ifdef RW
 UTEST(CVector, ctor_RwV3d)
 {
     RwV3d src;
@@ -61,7 +60,6 @@ UTEST(CVector, ctor_RwV3d)
     EXPECT_EQ(v.y, 2.0f);
     EXPECT_EQ(v.z, 3.0f);
 }
-#endif
 
 UTEST(CVector, ctor_CVector2D)
 {
@@ -120,8 +118,7 @@ UTEST(CVector, operator_assign)
     EXPECT_EQ(v.z, 3.0f);
 }
 
-#ifdef RW
-UTEST(CVector, FromRwV3d)
+UTEST(CVector, operator_assign_RwV3d)
 {
     RwV3d src;
     src.x = 1.0f;
@@ -129,12 +126,11 @@ UTEST(CVector, FromRwV3d)
     src.z = 3.0f;
     CVector v;
 
-    v.FromRwV3d(src);
+    v = src;
     EXPECT_EQ(v.x, 1.0f);
     EXPECT_EQ(v.y, 2.0f);
     EXPECT_EQ(v.z, 3.0f);
 }
-#endif
 
 UTEST(CVector, From2D)
 {
@@ -239,7 +235,6 @@ UTEST(CVector, FromMultiply3x3)
 
 // conversions
 
-#ifdef RW
 UTEST(CVector, ToRwV3d)
 {
     CVector src;
@@ -247,12 +242,11 @@ UTEST(CVector, ToRwV3d)
     src.y = 2.0f;
     src.z = 3.0f;
 
-    RwV3d v = src.ToRwV3d();
+    RwV3d v = src;
     EXPECT_EQ(v.x, 1.0f);
     EXPECT_EQ(v.y, 2.0f);
     EXPECT_EQ(v.z, 3.0f);
 }
-#endif
 
 UTEST(CVector, To2D)
 {

--- a/plugin_II/game_II/CVector2D.h
+++ b/plugin_II/game_II/CVector2D.h
@@ -8,7 +8,7 @@
 #pragma once
 #include "PluginBase.h"
 
-class CVector;
+struct CVector;
 class CVector2D;
 
 class CEncodedVector {

--- a/plugin_III/game_III/CVector2D.h
+++ b/plugin_III/game_III/CVector2D.h
@@ -9,7 +9,7 @@
 #include "PluginBase.h"
 #include <math.h>
 
-class CVector;
+struct CVector;
 
 class CVector2D {
 public:

--- a/plugin_sa/game_sa/CVector2D.h
+++ b/plugin_sa/game_sa/CVector2D.h
@@ -8,7 +8,7 @@
 
 #include "PluginBase.h"
 
-class CVector;
+struct CVector;
 
 class PLUGIN_API CVector2D
 {

--- a/plugin_vc/game_vc/CVector2D.h
+++ b/plugin_vc/game_vc/CVector2D.h
@@ -9,7 +9,7 @@
 #include "PluginBase.h"
 #include <math.h>
 
-class CVector;
+struct CVector;
 
 class CVector2D {
 public:

--- a/shared/extensions/FontPrint.cpp
+++ b/shared/extensions/FontPrint.cpp
@@ -194,7 +194,7 @@ bool Get3dTo2d(CVector const &posn, CVector &out) {
 #else
     RwV3d rwvec;
     float outw, outh;
-    result = CSprite::CalcScreenCoors(posn.ToRwV3d(),
+    result = CSprite::CalcScreenCoors(posn,
                                       &rwvec,
                                       &outw,
                                       &outh,
@@ -204,7 +204,7 @@ bool Get3dTo2d(CVector const &posn, CVector &out) {
 #endif
     );
 
-    out.FromRwV3d(rwvec);
+    out = rwvec;
 #endif
     return result;
 }

--- a/shared/extensions/FontPrint.h
+++ b/shared/extensions/FontPrint.h
@@ -9,11 +9,7 @@
 #include <string>
 #include <vector>
 #include "CRGBA.h"
-#ifdef RW
 #include "CVector.h"
-#elif RAGE
-#include "CVector.h"
-#endif
 #include "Screen.h"
 
 #ifdef GTA3

--- a/shared/game/CVector.h
+++ b/shared/game/CVector.h
@@ -6,8 +6,14 @@
 */
 #pragma once
 #include "PluginBase.h"
+
 #ifdef RW
     #include "RenderWare.h"
+#else
+    struct RwV3d
+    {
+        float x, y, z;
+    };
 #endif
 
 #if defined GTA3 || defined GTAVC || defined GTASA
@@ -17,21 +23,16 @@
 
 class CVector2D;
 
-class CVector
+struct CVector : public RwV3d
 {
 public:
-    float x = 0.0f;
-    float y = 0.0f;
-    float z = 0.0f;
-
     // constructors
-    CVector() = default;
+    CVector();
     explicit CVector(float value);
     CVector(float x, float y, float z);
     CVector(const CVector& src);
-#ifdef RW
     CVector(const RwV3d& src);
-#endif
+
     explicit CVector(const CVector2D& xy, float z = 0.0f);
     
     // assignments
@@ -39,9 +40,6 @@ public:
     void Set(float value); // assign value to all components
     void Set(float x, float y, float z);
     void operator =(const CVector& src);
-#ifdef RW
-    void FromRwV3d(const RwV3d& src);
-#endif
     void From2D(const CVector2D& xy, float z = 0.0f);
     void FromSum(const CVector& left, const CVector& right); // store sum of two vectors
     void FromDiff(const CVector& left, const CVector& right); // store left - right substraction result
@@ -53,9 +51,10 @@ public:
 #endif
 
     // conversions
-#ifdef RW
-    RwV3d ToRwV3d() const;
-#endif
+    operator RwV3d&();
+    operator const RwV3d&() const;
+    operator RwV3d*();
+    operator const RwV3d*() const;
     CVector2D To2D() const; // get XY
 
     // properties

--- a/shared/game/CVectorImplementation.h
+++ b/shared/game/CVectorImplementation.h
@@ -9,6 +9,12 @@
 
 // constructors
 
+inline CVector::CVector() {
+    x = 0.0f;
+    y = 0.0f;
+    z = 0.0f;
+}
+
 inline CVector::CVector(float value) {
     Set(value);
 }
@@ -18,14 +24,12 @@ inline CVector::CVector(float x, float y, float z) {
 }
 
 inline CVector::CVector(const CVector& src) {
-    *this = src;
+    Set(src.x, src.y, src.z);
 }
 
-#ifdef RW
 inline CVector::CVector(const RwV3d& src) {
-    FromRwV3d(src);
+    Set(src.x, src.y, src.z);
 }
-#endif
 
 inline CVector::CVector(const CVector2D& xy, float z) {
     Set(xy.x, xy.y, z);
@@ -50,12 +54,6 @@ inline void CVector::Set(float x, float y, float z) {
 inline void CVector::operator =(const CVector& src) {
     Set(src.x, src.y, src.z);
 }
-
-#ifdef RW
-inline void CVector::FromRwV3d(const RwV3d& src) {
-    Set(src.x, src.y, src.z);
-}
-#endif
 
 inline void CVector::From2D(const CVector2D& xy, float z) {
     Set(xy.x, xy.y, z);
@@ -89,11 +87,21 @@ inline void CVector::FromCross(const CVector& left, const CVector& right) {
 
 // conversions
 
-#ifdef RW
-inline RwV3d CVector::ToRwV3d() const {
-    return RwV3d(x, y, z);
+inline CVector::operator RwV3d&() {
+    return *this;
 }
-#endif
+
+inline CVector::operator const RwV3d&() const {
+    return *this;
+}
+
+inline CVector::operator RwV3d*() {
+    return reinterpret_cast<RwV3d*>(this);
+}
+
+inline CVector::operator const RwV3d*() const {
+    return reinterpret_cast<const RwV3d*>(this);
+}
 
 inline CVector2D CVector::To2D() const {
     return CVector2D(x, y);

--- a/shared/game/CompressedVector.cpp
+++ b/shared/game/CompressedVector.cpp
@@ -7,11 +7,7 @@
 #pragma once
 #include "CompressedVector.h"
 #include "CompressedVector2D.h"
-
-#ifdef RW
-#include "RenderWare.h"
 #include "CVector.h"
-#endif
 
 CompressedVector::CompressedVector() {
     Set(0, 0, 0);
@@ -29,15 +25,9 @@ CompressedVector::CompressedVector(CompressedVector2D const & rhs) {
     Set(rhs);
 }
 
-#if defined(GTA3) || defined(GTAVC) || defined(GTASA)
 CompressedVector::CompressedVector(CVector const & rhs) {
     Set(rhs);
 }
-
-CompressedVector::CompressedVector(RwV3d const & rhs) {
-    Set(rhs);
-}
-#endif
 
 void CompressedVector::Set(short X, short Y, short Z) {
     x = X;
@@ -57,14 +47,7 @@ void CompressedVector::Set(CompressedVector2D const & rhs) {
     z = 0;
 }
 
-#ifdef RW
 void CompressedVector::Set(CVector const & rhs) {
-    x = static_cast<short>(rhs.x * 8.0f);
-    y = static_cast<short>(rhs.y * 8.0f);
-    z = static_cast<short>(rhs.z * 8.0f);
-}
-
-void CompressedVector::Set(RwV3d const & rhs) {
     x = static_cast<short>(rhs.x * 8.0f);
     y = static_cast<short>(rhs.y * 8.0f);
     z = static_cast<short>(rhs.z * 8.0f);
@@ -74,24 +57,13 @@ CVector CompressedVector::Uncompressed() const {
     return CVector(static_cast<float>(x) / 8.0f, static_cast<float>(y) / 8.0f, static_cast<float>(z) / 8.0f);
 }
 
-RwV3d CompressedVector::ToRwV3d() const {
-    RwV3d result;
-    result.x = static_cast<float>(x) / 8.0f;
-    result.y = static_cast<float>(y) / 8.0f;
-    result.z = static_cast<float>(z) / 8.0f;
-    return result;
-}
-#endif
-
 CompressedVector2D CompressedVector::To2D() const {
     return CompressedVector2D(x, y);
 }
 
-#if defined(GTA3) || defined(GTAVC) || defined(GTASA)
 void CompressedVector::Uncompress(CVector &out) const {
     out = Uncompressed();
 }
-#endif
 
 bool CompressedVector::operator==(CompressedVector const &rhs) const {
     return x == rhs.x && y == rhs.y && z == rhs.z;

--- a/shared/game/CompressedVector.h
+++ b/shared/game/CompressedVector.h
@@ -8,8 +8,7 @@
 
 #include "PluginBase.h"
 
-class CVector;
-struct RwV3d;
+struct CVector;
 class CompressedVector2D;
 
 class PLUGIN_API CompressedVector {
@@ -22,29 +21,17 @@ public:
     CompressedVector(short X, short Y, short Z);
     CompressedVector(CompressedVector const &rhs);
     CompressedVector(CompressedVector2D const &rhs);
-
-#ifdef RW
     CompressedVector(CVector const &rhs);
-    CompressedVector(RwV3d const &rhs);
-#endif
 
     void Set(short X, short Y, short Z);
     void Set(CompressedVector const &rhs);
     void Set(CompressedVector2D const &rhs);
-
-#ifdef RW
     void Set(CVector const &rhs);
-    void Set(RwV3d const &rhs);
 
     CVector Uncompressed() const;
-    RwV3d ToRwV3d() const;
-#endif
+    void Uncompress(CVector &out) const;
 
     CompressedVector2D To2D() const;
-
-#ifdef RW
-    void Uncompress(CVector &out) const;
-#endif
 
     bool operator==(CompressedVector const &rhs) const;
     bool operator!=(CompressedVector const &rhs) const;


### PR DESCRIPTION
Instead of having two structs with same members `CVector` in now based on `RwV3d` (reversed project does it too).
Added conversion operators, so both types can be used interchangeable.
Got rid of manual conversion methods.