### PR TITLE
Fix string macros bug

### DIFF
--- a/shared/Base.h
+++ b/shared/Base.h
@@ -49,7 +49,7 @@ typedef unsigned int uint;
 // III/VC char > wchar_t string conversion
 #define _SWSTRING_INIT(str, id) std::wstring my_ws##id; for (size_t i = 0; i < strlen(str); i++) my_ws##id += str[i]
 #define _SWSTRING(id) my_ws##id.c_str()
-#define _SWSTRING_STATIC_INIT(id) static wchar_t my_ws##id[512] ; my_ws##id[0] = 0
+#define _SWSTRING_STATIC_INIT(id) static wchar_t my_ws##id[512]; my_ws##id[0] = 0
 #define _SWSTRING_STATIC(id) my_ws##id
-#define _SWSTRING_STATIC_FROM(id, src) for (size_t i = 0; i < strlen(src); i++) my_ws##id[i] = src[i]
-#define _SWSTRING_STATIC_TO(id, dst) for (size_t i = 0; i < wcslen(my_ws##id); i++) dst[i] = static_cast<char>(my_ws##id[i])
+#define _SWSTRING_STATIC_FROM(id, src) { auto i = (int)strlen(src); my_ws##id[i] = '\0'; while (--i >= 0) my_ws##id[i] = src[i]; }
+#define _SWSTRING_STATIC_TO(id, dst) { auto i = (int)wcslen(my_ws##id); dst[i] = '\0'; while (--i >= 0) dst[i] = static_cast<char>(my_ws##id[i]); }


### PR DESCRIPTION
Macros **_SWSTRING_STATIC_FROM** and **_SWSTRING_STATIC_TO** are not adding string terminator character to converted text.