### PR TITLE
Update III CRunningScript.h

### DIFF
--- a/plugin_III/game_III/CRunningScript.h
+++ b/plugin_III/game_III/CRunningScript.h
@@ -43,8 +43,10 @@ public:
     int             m_anTimers[2];
     bool            m_bCondResult;
     bool            m_bUseMissionCleanup;
-    bool            m_bIsActive;
-    bool            m_bAwake;
+    bool            m_bSkipWakeTime;
+private:
+    char _pad7B;
+public:
     int             m_nWakeTime;
     unsigned short  m_nLogicalOp;
     bool            m_bNotFlag;
@@ -75,8 +77,7 @@ VALIDATE_OFFSET(CRunningScript, m_aLocalVars, 0x30);
 VALIDATE_OFFSET(CRunningScript, m_anTimers, 0x70);
 VALIDATE_OFFSET(CRunningScript, m_bCondResult, 0x78);
 VALIDATE_OFFSET(CRunningScript, m_bUseMissionCleanup, 0x79);
-VALIDATE_OFFSET(CRunningScript, m_bIsActive, 0x7A);
-VALIDATE_OFFSET(CRunningScript, m_bAwake, 0x7B);
+VALIDATE_OFFSET(CRunningScript, m_bSkipWakeTime, 0x7A);
 VALIDATE_OFFSET(CRunningScript, m_nWakeTime, 0x7C);
 VALIDATE_OFFSET(CRunningScript, m_nLogicalOp, 0x80);
 VALIDATE_OFFSET(CRunningScript, m_bNotFlag, 0x82);


### PR DESCRIPTION
GTA 3's CRunningScript never had `m_bIsActive` flag, only VC did. In VC that flag was seldom used to track script's activity (running/terminated), but it was redundant since game already did this with 2 lists: `pActiveScripts` and `pIdleScripts`

Moreover, the order of flags is wrong in current definition. Also, `m_bAwake` can have it's name changed to proposed `m_bSkipWakeTime` to better reflect it's function.