### PR TITLE
Update VC CRunningScript.h

### DIFF
--- a/plugin_vc/game_vc/CRunningScript.h
+++ b/plugin_vc/game_vc/CRunningScript.h
@@ -44,7 +44,7 @@ public:
     bool            m_bIsActive;
     bool            m_bCondResult;
     bool            m_bUseMissionCleanup;
-    bool            m_bAwake;
+    bool            m_bSkipWakeTime;
     int             m_nWakeTime;
     unsigned short  m_nLogicalOp;
     bool            m_bNotFlag;


### PR DESCRIPTION
`m_bAwake` can have it's name changed to proposed `m_bSkipWakeTime` to better reflect it's function.