### PR TITLE
Fix CMenuManager::DrawQuitGameScreen signature

### DIFF
--- a/plugin_sa/game_sa/CMenuManager.cpp
+++ b/plugin_sa/game_sa/CMenuManager.cpp
@@ -103,8 +103,8 @@ void CMenuManager::DrawFrontEnd() {
     plugin::CallMethod<0x57C290, CMenuManager*>(this);
 }
 
-void CMenuManager::DrawQuitGameScreen(int unused) {
-    plugin::CallMethod<0x57D860, CMenuManager*>(this, unused);
+void CMenuManager::DrawQuitGameScreen() {
+    plugin::CallMethod<0x57D860, CMenuManager*>(this);
 }
 
 void CMenuManager::DrawStandardMenu(bool header) {

--- a/plugin_sa/game_sa/CMenuManager.h
+++ b/plugin_sa/game_sa/CMenuManager.h
@@ -409,7 +409,7 @@ public:
     char DrawControllerScreenExtraText(int unk);
     char DrawControllerSetupScreen();
     void DrawFrontEnd();
-    void DrawQuitGameScreen(int unused);
+    void DrawQuitGameScreen();
     void DrawStandardMenu(bool header = true);
     void DrawWindow(const CRect& coords, const char* pKey, unsigned char nColour, CRGBA backColor, bool Unused, bool bBackground);
     void DrawWindowedText(float x1, float y1, float x2, float y2, char* gxt, int align);


### PR DESCRIPTION
Removes the incorrect `int unused` parameter from `CMenuManager::DrawQuitGameScreen`.

The function at `0x57D860` in GTA SA 1.0 US uses ECX as this and ends with a plain:
```asm
ret
```
rather than:
```asm
ret 4
```
For an `x86 __thiscall` function, a single explicit 32-bit argument would be passed on the stack and cleaned up by the callee with `ret 4`, even if the argument itself was unused.

Therefore the function appears to have no explicit parameters.

Changed from:
```cpp
void CMenuManager::DrawQuitGameScreen(int unused) {
    plugin::CallMethod<0x57D860, CMenuManager*>(this, unused);
}
```
to:
```cpp
void CMenuManager::DrawQuitGameScreen() {
    plugin::CallMethod<0x57D860, CMenuManager*>(this);
}
```
This also avoids the stack/calling-convention mismatch caused by passing an argument to a function that does not clean it up.