### PR TITLE
Fix CPedDamageResponse& argument deduction in ComputeWillKillPed

### DIFF
--- a/plugin_sa/game_sa/CPedDamageResponseCalculator.cpp
+++ b/plugin_sa/game_sa/CPedDamageResponseCalculator.cpp
@@ -30,7 +30,7 @@ bool CPedDamageResponseCalculator::ComputeWillForceDeath(CPed* ped, CPedDamageRe
 
 // 0x4B3210
 void CPedDamageResponseCalculator::ComputeWillKillPed(CPed* ped, CPedDamageResponse& response, bool bSpeak) {
-    plugin::CallMethod<0x4B3210, CPedDamageResponseCalculator*>(this, ped, response, bSpeak);
+    plugin::CallMethod<0x4B3210, CPedDamageResponseCalculator*, CPed*, CPedDamageResponse&, bool>(this, ped, response, bSpeak);
 }
 
 // 0x4B5AC0


### PR DESCRIPTION
## Summary

Fixes an incorrect argument type deduction in `CPedDamageResponseCalculator::ComputeWillKillPed`.

`plugin::CallMethod` takes its argument pack as `Args... args`, so when the argument types are not specified explicitly, the reference on `CPedDamageResponse&` is stripped during template argument deduction.

As a result, the current code deduces `CPedDamageResponse` by value instead of `CPedDamageResponse&`, producing an incorrect function signature/ABI for the call to `0x4B3210`.

## Verification

The original `gta_sa.exe` confirms that `0x4B3210` expects the second argument as a single pointer/reference-sized stack argument.

A native call site passes three DWORD arguments:

```asm
push eax        ; bSpeak
push ebp        ; &response
push edi        ; ped
mov  ecx, esi   ; this
call 0x4B3210
```

Inside `0x4B3210`, the second argument is loaded into `EDI` and then dereferenced:

```asm
mov edi, DWORD PTR [esp+0x18]
...
mov BYTE PTR [edi+0x9], al
...
fstp DWORD PTR [edi]
```

The function also ends with:

```asm
ret 0xC
```

which confirms that it expects exactly three 4-byte stack arguments.

Without explicitly specifying `CPedDamageResponse&`, `CallMethod` deduces the argument pack as approximately:

```cpp
CPed*, CPedDamageResponse, bool
```

instead of:

```cpp
CPed*, CPedDamageResponse&, bool
```

which results in an incompatible call ABI.
