### PR TITLE
Fix const CRect& argument deduction in CMenuManager::DrawWindow

### DIFF
--- a/plugin_sa/game_sa/CMenuManager.cpp
+++ b/plugin_sa/game_sa/CMenuManager.cpp
@@ -112,7 +112,7 @@ void CMenuManager::DrawStandardMenu(bool header) {
 }
 
 void CMenuManager::DrawWindow(const CRect& coords, const char* pKey, unsigned char nColour, CRGBA backColor, bool Unused, bool bBackground) {
-    plugin::CallMethod<0x573EE0, CMenuManager*>(this, coords, pKey, nColour, backColor, Unused, bBackground);
+    plugin::CallMethod<0x573EE0, CMenuManager*, const CRect&, const char*, unsigned char, CRGBA, bool, bool>(this, coords, pKey, nColour, backColor, Unused, bBackground);
 }
 
 void CMenuManager::DrawWindowedText(float x1, float y1, float x2, float y2, char* gxt, int align) {


### PR DESCRIPTION
## Summary

Fixes an incorrect argument type deduction in `CMenuManager::DrawWindow`.

`plugin::CallMethod` takes its argument pack as `Args... args`, so when the argument types are not specified explicitly, the reference and top-level `const` on `const CRect&` are stripped during template argument deduction.

As a result, the current code deduces `CRect` by value instead of `const CRect&`, producing an incorrect function signature/ABI for the call to `0x573EE0`.

## Verification

The original `gta_sa.exe` confirms that `0x573EE0` expects the first argument as a single pointer/reference-sized stack argument.

Native call sites construct a `CRect`, take its address, and pass that address as the first argument:

```asm
lea  ecx, [esp+0x38]
push ecx
mov  ecx, 0xba6748
call 0x573ee0
```

The same pattern appears at several other call sites:

```asm
lea  edx, [esp+0x24]
push edx
mov  ecx, esi
call 0x573ee0
```

Inside `0x573EE0`, the first argument is loaded into `ESI` and then used as a pointer to access `CRect` fields:

```asm
mov  esi, DWORD PTR [esp+0x8]
...
fld  DWORD PTR [esi+0xc]
fcomp DWORD PTR [esi+0x4]
...
fadd DWORD PTR [esi]
```

The function also ends with:

```asm
ret 0x18
```

which confirms that it expects six 4-byte stack arguments.

Without explicitly specifying `const CRect&`, `CallMethod` deduces the argument pack as approximately:

```cpp
CRect, const char*, unsigned char, CRGBA, bool, bool
```

instead of:

```cpp
const CRect&, const char*, unsigned char, CRGBA, bool, bool
```

which results in an incompatible call ABI.
